### PR TITLE
Check root privileges in srv6_manager

### DIFF
--- a/srv6_controller/node-manager/srv6_manager.py
+++ b/srv6_controller/node-manager/srv6_manager.py
@@ -331,6 +331,12 @@ def start_server(grpc_ip=DEFAULT_GRPC_IP,
         time.sleep(5)
 
 
+# Check whether we have root permission or not
+# Return True if we have root permission, False otherwise
+def check_root():
+    return os.getuid() == 0
+
+
 # Parse options
 def parse_arguments():
     # Get parser
@@ -385,5 +391,9 @@ if __name__ == '__main__':
     # Debug settings
     server_debug = logger.getEffectiveLevel() == logging.DEBUG
     logging.info('SERVER_DEBUG:' + str(server_debug))
+    # This script must be run as root
+    if not check_root():
+        print('*** %s must be run as root.\n' % sys.argv[0])
+        exit(1)
     # Start the server
     start_server(grpc_ip, grpc_port, secure, certificate, key)


### PR DESCRIPTION
srv6_manager uses pyroute2 library to manage seg6 and seg6local routes.

Since pyroute2 needs root permission to write changes to the kernel, we must ensure that srv6_manager is started as root.