### PR TITLE
Fix an issue of the topology extraction algorithm entering a endless extraction loop when the controller is not able to reach the nodes

### DIFF
--- a/control_plane/controller/controller/arangodb_utils.py
+++ b/control_plane/controller/controller/arangodb_utils.py
@@ -273,8 +273,8 @@ def extract_topo_from_isis_and_load_on_arango(isis_nodes, isisd_pwd,
                     edges_collection=edges_collection,
                     verbose=verbose
                 )
-            # Period = 0 means a single extraction
-            if period == 0:
-                break
+        # Period = 0 means a single extraction
+        if period == 0:
+            break
         # Wait 'period' seconds between two extractions
         time.sleep(period)


### PR DESCRIPTION
This PR resolves #42 