### PR TITLE
Setup Release Drafter github action to automate the creation of release drafts

### DIFF
--- a/.github/label-pr.yml
+++ b/.github/label-pr.yml
@@ -1,0 +1,10 @@
+- regExp: ".*\\.ts+$"
+  labels: ["typescript"]
+- regExp: ".*\\.sql+$"
+  labels: ["database", "critical"]
+- regExp: ".*\\.md+$"
+  labels: ["documentation"]
+- regExp: "^(pom\\.xml|package\\.json|build\\.gradle)$"
+  labels: ["dependencies"]
+- regExp: ".*\\.(zip|jar|war|ear)+$"
+  labels: ["artifact", "invalid"]

--- a/.github/label-pr.yml
+++ b/.github/label-pr.yml
@@ -24,3 +24,5 @@
   labels: ["protos"]
 - regExp: ".*/setup.py"
   labels: ["build"]
+- regExp: "^.github/"
+  labels: ["github-workflow"]

--- a/.github/label-pr.yml
+++ b/.github/label-pr.yml
@@ -2,9 +2,23 @@
   labels: ["typescript"]
 - regExp: ".*\\.sql+$"
   labels: ["database", "critical"]
-- regExp: ".*\\.md+$"
+- regExp: "^docs/"
   labels: ["documentation"]
+- regExp: ".*\\.png+$"
+  labels: ["images"]
 - regExp: "^(pom\\.xml|package\\.json|build\\.gradle)$"
+  labels: ["dependencies"]
+- regExp: ".*/requirements.txt"
   labels: ["dependencies"]
 - regExp: ".*\\.(zip|jar|war|ear)+$"
   labels: ["artifact", "invalid"]
+- regExp: "^db_update/"
+  labels: ["database utilities"]
+- regExp: "^control_plane/node-manager/"
+  labels: ["node manager"]
+- regExp: "^control_plane/controller/"
+  labels: ["controller"]
+- regExp: "^control_plane/examples/"
+  labels: ["examples"]
+- regExp: "^control_plane/protos/"
+  labels: ["protos"]

--- a/.github/label-pr.yml
+++ b/.github/label-pr.yml
@@ -22,3 +22,5 @@
   labels: ["examples"]
 - regExp: "^control_plane/protos/"
   labels: ["protos"]
+- regExp: ".*/setup.py"
+  labels: ["build"]

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,3 +1,3 @@
 feature: ['feature/*', 'feat/*', 'feature-*', 'feat-*']
-fix: ['fix/*', 'fix-*']
+bug: ['fix/*', 'fix-*']
 chore: ['chore/*', 'chore-*']

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,3 @@
+feature: ['feature/*', 'feat/*', 'feature-*', 'feat-*']
+fix: ['fix/*', 'fix-*']
+chore: ['chore/*', 'chore-*']

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,6 +24,8 @@ version-resolver:
     labels:
       - 'patch'
   default: patch
+exclude-labels:
+  - 'skip-changelog'
 template: |
   ## Changes
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,9 +20,14 @@ version-resolver:
   minor:
     labels:
       - 'minor'
+      - 'feature'
+      - 'enhancement'
   patch:
     labels:
       - 'patch'
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
   default: patch
 exclude-labels:
   - 'skip-changelog'

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -30,7 +30,7 @@ jobs:
           committer: Carmine Scarpitta <carmine.scarpitta@uniroma2.it>
           title: Fixes by autopep8 action
           body: This is an auto-generated PR with fixes by autopep8.
-          labels: autopep8, automated pr
+          labels: autopep8, automated pr, skip-changelog
           reviewers: cscarpitta
           branch: ${{ steps.vars.outputs.branch-name }}
       - name: Fail if autopep8 made changes

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -8,11 +8,20 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    
       # We need to checkout the repository to access the configured file (.github/label-pr.yml)
       - uses: actions/checkout@v2
-      
       - name: Labeler
         uses: docker://decathlon/pull-request-labeler-action:2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Here we can override the path for the action configuration. If none is provided, default one is `.github/label-pr.yml`
+          # CONFIG_PATH: ${{ secrets.GITHUB_WORKSPACE }}/.github/label-pr.yml
+
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        # with:
+        #  configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -1,0 +1,18 @@
+# Workflow to associate labels automatically
+name: labeler
+
+# Trigger the workflow on pull request events
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    
+      # We need to checkout the repository to access the configured file (.github/label-pr.yml)
+      - uses: actions/checkout@v2
+      
+      - name: Labeler
+        uses: docker://decathlon/pull-request-labeler-action:2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -11,7 +11,7 @@ jobs:
       # We need to checkout the repository to access the configured file (.github/label-pr.yml)
       - uses: actions/checkout@v2
       - name: Labeler
-        uses: docker://decathlon/pull-request-labeler-action:2.0.1
+        uses: docker://decathlon/pull-request-labeler-action:2.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Here we can override the path for the action configuration. If none is provided, default one is `.github/label-pr.yml`

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        # with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+          # config-name: my-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR will add Release Drafter and PR Labeler github actions in order to implement semantic versioning and to automate the creation of release drafts.
This PR closes #53 