### PR TITLE
Add support for SID lists expressed numerically in uSID policies

### DIFF
--- a/control_plane/controller/controller/arangodb_driver.py
+++ b/control_plane/controller/controller/arangodb_driver.py
@@ -426,7 +426,7 @@ def insert_nodes_config(database, nodes):
     # Create a new 'nodes_config' collection
     nodes_config = database.create_collection(name='nodes_config')
     # Insert the nodes config
-    return nodes_config.insert(document=nodes.values(), silent=True)
+    return nodes_config.insert(document=list(nodes.values()), silent=True)
 
 
 def get_nodes_config(database):

--- a/control_plane/controller/controller/arangodb_driver.py
+++ b/control_plane/controller/controller/arangodb_driver.py
@@ -438,6 +438,9 @@ def get_nodes_config(database):
     :return: Dict reresentation of the nodes saved to the db. For a
              of the node entries, see :func:`insert_nodes_config`.
     :rtype: dict
+    :raises controller.arangodb_driver.NodesConfigNotLoadedError: If nodes are
+                                                                  not loaded
+                                                                  on db.
     '''
     # Does the collection 'nodes_config' exist?
     if not database.has_collection('nodes_config'):

--- a/control_plane/controller/controller/cli/cli.py
+++ b/control_plane/controller/controller/cli/cli.py
@@ -52,6 +52,8 @@ from dotenv import load_dotenv
 from pkg_resources import resource_filename
 
 # Controller dependencies
+from controller import arangodb_driver
+from controller import srv6_usid
 from controller.cli import srv6_cli, srv6pm_cli, topo_cli
 from controller.init_db import init_srv6_usid_db
 
@@ -155,6 +157,67 @@ class ControllerCLITopology(CustomCmd):
 
     prompt = "controller(topology)> "
 
+    def do_show_nodes(self, args):
+        """Show nodes"""
+
+        # pylint: disable=no-self-use, unused-argument
+
+        try:
+            # args = (srv6_cli
+            #         .parse_arguments_print_nodes(
+            #             prog='print_nodes', args=args.split(' ')))
+            pass
+        except SystemExit:
+            return False  # This workaround avoid exit in case of errors
+        # pylint: disable=no-self-use
+        #
+        # ArangoDB params
+        arango_url = os.getenv('ARANGO_URL')
+        arango_user = os.getenv('ARANGO_USER')
+        arango_password = os.getenv('ARANGO_PASSWORD')
+        # Connect to ArangoDB
+        client = arangodb_driver.connect_arango(
+            url=arango_url)     # TODO keep arango connection open
+        # Connect to the db
+        database = arangodb_driver.connect_srv6_usid_db(
+            client=client,
+            username=arango_user,
+            password=arango_password
+        )
+        nodes_dict = arangodb_driver.get_nodes_config(database)
+        srv6_cli.print_nodes(nodes_dict=nodes_dict)
+        # Return False in order to keep the CLI subsection open
+        # after the command execution
+        return False
+
+    def do_load_nodes_config(self, args):
+        '''Load node configuration to database'''
+        # pylint: disable=no-self-use
+        #
+        # Parse arguments
+        try:
+            args = srv6_cli.parse_arguments_load_nodes_config(
+                prog='load_nodes_config',
+                args=args.split(' ')
+            )
+        except SystemExit:
+            return False  # This workaround avoid exit in case of errors
+        # ArangoDB params
+        arango_url = os.getenv('ARANGO_URL')
+        arango_user = os.getenv('ARANGO_USER')
+        arango_password = os.getenv('ARANGO_PASSWORD')
+        # Connect to ArangoDB
+        client = arangodb_driver.connect_arango(
+            url=arango_url)     # TODO keep arango connection open
+        # Connect to the db
+        database = arangodb_driver.connect_srv6_usid_db(
+            client=client,
+            username=arango_user,
+            password=arango_password
+        )
+        arangodb_driver.insert_nodes_config(database, srv6_usid.read_nodes(
+            args.nodes_file)[0])
+
     def do_extract(self, args):
         """Extract the network topology"""
 
@@ -237,6 +300,44 @@ class ControllerCLITopology(CustomCmd):
         # after the command execution
         return False
 
+    def complete_show_nodes(self, text, line, start_idx, end_idx):
+        """Auto-completion for show_nodes command"""
+
+        # pylint: disable=no-self-use, unused-argument
+
+        # Get the previous argument in the command
+        # Depending on the previous argument, it is possible to
+        # complete specific params, such as the paths
+        #
+        # Split args
+        args = line[:start_idx].split(' ')
+        # If this is not the first arg, get the previous one
+        prev_text = None
+        if len(args) > 1:
+            prev_text = args[-2]    # [-2] because last element is always ''
+        # Call auto-completion function and return a list of
+        # possible arguments
+        return srv6_cli.complete_print_nodes(text, prev_text)
+
+    def complete_load_nodes_config(self, text, line, start_idx, end_idx):
+        """Auto-completion for load_nodes_config command"""
+
+        # pylint: disable=no-self-use, unused-argument
+
+        # Get the previous argument in the command
+        # Depending on the previous argument, it is possible to
+        # complete specific params, such as the paths
+        #
+        # Split args
+        args = line[:start_idx].split(' ')
+        # If this is not the first arg, get the previous one
+        prev_text = None
+        if len(args) > 1:
+            prev_text = args[-2]    # [-2] because last element is always ''
+        # Call auto-completion function and return a list of
+        # possible arguments
+        return srv6_cli.complete_load_nodes_config(text, prev_text)
+
     def complete_extract(self, text, line, start_idx, end_idx):
         """Auto-completion for extract command"""
 
@@ -297,6 +398,26 @@ class ControllerCLITopology(CustomCmd):
         return (topo_cli
                 .complete_extract_topo_from_isis_and_load_on_arango(
                     text, prev_text))
+
+    def help_show_nodes(self):
+        """Show help usage for show_nodes config command"""
+        #
+        # pylint: disable=no-self-use
+        #
+        srv6_cli.parse_arguments_print_nodes(
+            prog='show_nodes',
+            args=['--help']
+        )
+
+    def help_load_nodes_config(self):
+        """Show help usage for load_nodes_config nodes command"""
+        #
+        # pylint: disable=no-self-use
+        #
+        srv6_cli.parse_arguments_load_nodes_config(
+            prog='load_nodes_config',
+            args=['--help']
+        )
 
     def help_extract(self):
         """Show help usage for extract command"""
@@ -653,124 +774,6 @@ class ControllerCLISRv6PM(CustomCmd):
         sub_cmd.cmdloop()
 
 
-class ControllerCLISRv6USID(CustomCmd):
-    """srv6-usid subsection"""
-
-    prompt = "controller(srv6-usid)> "
-
-    def __init__(self, nodes_filename, *args):
-        # File containing the mapping node names to IP addresses
-        self.nodes_filename = nodes_filename
-        # Remove leading and trailing apices
-        if self.nodes_filename[0] == "'" and self.nodes_filename[-1] == "'":
-            self.nodes_filename = self.nodes_filename[1:-1]
-        elif self.nodes_filename[0] == '"' and self.nodes_filename[-1] == '"':
-            self.nodes_filename = self.nodes_filename[1:-1]
-        # Show the nodes available automatically when
-        # the uSID subsection is opened
-        # srv6_cli.print_node_to_addr_mapping(self.nodes_filename)
-
-        from controller import arangodb_driver
-        # ArangoDB params
-        arango_url = os.getenv('ARANGO_URL')
-        arango_user = os.getenv('ARANGO_USER')
-        arango_password = os.getenv('ARANGO_PASSWORD')
-        # Connect to ArangoDB
-        client = arangodb_driver.connect_arango(
-            url=arango_url)     # TODO keep arango connection open
-        # Connect to the db
-        database = arangodb_driver.connect_srv6_usid_db(
-            client=client,
-            username=arango_user,
-            password=arango_password
-        )
-        arangodb_driver.get_nodes_config(database)
-        CustomCmd.__init__(self, *args)
-
-    def do_nodes(self, args):
-        """Show nodes"""
-
-        # pylint: disable=no-self-use, unused-argument
-
-        srv6_cli.print_node_to_addr_mapping(self.nodes_filename)
-        # Return False in order to keep the CLI subsection open
-        # after the command execution
-        return False
-
-    def help_nodes(self):
-        """Show help usage for nodes command"""
-        #
-        # pylint: disable=no-self-use
-        #
-        print('Show the list of the available devices')
-
-    def do_policy(self, args):
-        """Handle a SRv6 uSID policy"""
-
-        # pylint: disable=no-self-use, unused-argument
-
-        try:
-            args = srv6_cli.parse_arguments_srv6_usid_policy(
-                prog='policy',
-                args=args.split(' ')
-            )
-        except SystemExit:
-            return False  # This workaround avoid exit in case of errors
-        srv6_cli.handle_srv6_usid_policy(
-            operation=args.op,
-            nodes_filename=self.nodes_filename,
-            lr_destination=args.lr_destination,
-            rl_destination=args.rl_destination,
-            nodes_lr=args.nodes,
-            nodes_rl=args.nodes_rev,
-            table=args.table,
-            metric=args.metric,
-            _id=args.id,
-            l_grpc_ip=args.l_grpc_ip,
-            l_grpc_port=args.l_grpc_port,
-            l_fwd_engine=args.l_fwd_engine,
-            r_grpc_ip=args.r_grpc_ip,
-            r_grpc_port=args.r_grpc_port,
-            r_fwd_engine=args.r_fwd_engine,
-            decap_sid=args.decap_sid,
-            locator=args.locator
-        )
-        # Print nodes available
-        srv6_cli.print_node_to_addr_mapping(self.nodes_filename)
-        # Return False in order to keep the CLI subsection open
-        # after the command execution
-        return False
-
-    def complete_policy(self, text, line, start_idx, end_idx):
-        """Auto-completion for policy command"""
-
-        # pylint: disable=no-self-use, unused-argument
-
-        # Get the previous argument in the command
-        # Depending on the previous argument, it is possible to
-        # complete specific params, such as the paths
-        #
-        # Split args
-        args = line[:start_idx].split(' ')
-        # If this is not the first arg, get the previous one
-        prev_text = None
-        if len(args) > 1:
-            prev_text = args[-2]    # [-2] because last element is always ''
-        # Call auto-completion function and return a list of
-        # possible arguments
-        return srv6_cli.complete_srv6_usid_policy(text, prev_text)
-
-    def help_policy(self):
-        """Show help usage for policy command"""
-
-        # pylint: disable=no-self-use
-
-        srv6_cli.parse_arguments_srv6_usid_policy(
-            prog='policy',
-            args=['--help']
-        )
-
-
 class ControllerCLISRv6(CustomCmd):
     """srv6 subsection"""
 
@@ -836,43 +839,6 @@ class ControllerCLISRv6(CustomCmd):
         # after the command execution
         return False
 
-    def do_usid(self, args):
-        """Enter uSID subsection"""
-
-        # pylint: disable=no-self-use, unused-argument
-
-        try:
-            args = srv6_cli.parse_arguments_srv6_usid(
-                prog='usid',
-                args=args.split(' ')
-            )
-        except SystemExit:
-            return False  # This workaround avoid exit in case of errors
-        try:
-            from controller import arangodb_driver
-            # ArangoDB params
-            arango_url = os.getenv('ARANGO_URL')
-            arango_user = os.getenv('ARANGO_USER')
-            arango_password = os.getenv('ARANGO_PASSWORD')
-            # Connect to ArangoDB
-            client = arangodb_driver.connect_arango(
-                url=arango_url)     # TODO keep arango connection open
-            # Connect to the db
-            database = arangodb_driver.connect_srv6_usid_db(
-                client=client,
-                username=arango_user,
-                password=arango_password
-            )
-            from controller import srv6_usid
-            arangodb_driver.insert_nodes_config(database, srv6_usid.read_nodes(args.nodes_file)[0])
-            sub_cmd = ControllerCLISRv6USID(
-                nodes_filename=args.nodes_file
-            )
-            sub_cmd.cmdloop()
-            return False
-        except FileNotFoundError:
-            logger.error('File not found %s', args.nodes_file)
-
     def do_unitunnel(self, args):
         """Handle a SRv6 unidirectional tunnel"""
 
@@ -928,6 +894,59 @@ class ControllerCLISRv6(CustomCmd):
             bsid_addr=args.bsid_addr,
             fwd_engine=args.fwd_engine
         )
+        # Return False in order to keep the CLI subsection open
+        # after the command execution
+        return False
+
+    def do_usid_policy(self, args):
+        """Handle a SRv6 uSID policy"""
+
+        # pylint: disable=no-self-use, unused-argument
+
+        try:
+            args = srv6_cli.parse_arguments_srv6_usid_policy(
+                prog='usid_policy',
+                args=args.split(' ')
+            )
+        except SystemExit:
+            return False  # This workaround avoid exit in case of errors
+        # ArangoDB params
+        arango_url = os.getenv('ARANGO_URL')
+        arango_user = os.getenv('ARANGO_USER')
+        arango_password = os.getenv('ARANGO_PASSWORD')
+        # Connect to ArangoDB
+        client = arangodb_driver.connect_arango(
+            url=arango_url)     # TODO keep arango connection open
+        # Connect to the db
+        database = arangodb_driver.connect_srv6_usid_db(
+            client=client,
+            username=arango_user,
+            password=arango_password
+        )
+        # Retrieve the nodes configuration from the database
+        nodes_dict = arangodb_driver.get_nodes_config(database)
+        # Handle the uSID policy
+        srv6_cli.handle_srv6_usid_policy(
+            operation=args.op,
+            nodes_dict=nodes_dict,
+            lr_destination=args.lr_destination,
+            rl_destination=args.rl_destination,
+            nodes_lr=args.nodes,
+            nodes_rl=args.nodes_rev,
+            table=args.table,
+            metric=args.metric,
+            _id=args.id,
+            l_grpc_ip=args.l_grpc_ip,
+            l_grpc_port=args.l_grpc_port,
+            l_fwd_engine=args.l_fwd_engine,
+            r_grpc_ip=args.r_grpc_ip,
+            r_grpc_port=args.r_grpc_port,
+            r_fwd_engine=args.r_fwd_engine,
+            decap_sid=args.decap_sid,
+            locator=args.locator
+        )
+        # Print nodes available
+        srv6_cli.print_nodes(nodes_dict=nodes_dict)
         # Return False in order to keep the CLI subsection open
         # after the command execution
         return False
@@ -1008,8 +1027,8 @@ class ControllerCLISRv6(CustomCmd):
         # possible arguments
         return srv6_cli.complete_srv6_biditunnel(text, prev_text)
 
-    def complete_usid(self, text, line, start_idx, end_idx):
-        """Auto-completion for usid command"""
+    def complete_usid_policy(self, text, line, start_idx, end_idx):
+        """Auto-completion for usid_policy command"""
 
         # pylint: disable=no-self-use, unused-argument
 
@@ -1025,7 +1044,7 @@ class ControllerCLISRv6(CustomCmd):
             prev_text = args[-2]    # [-2] because last element is always ''
         # Call auto-completion function and return a list of
         # possible arguments
-        return srv6_cli.complete_srv6_usid(text, prev_text)
+        return srv6_cli.complete_usid_policy(text, prev_text)
 
     def help_path(self):
         """Show help usage for path command"""
@@ -1067,14 +1086,14 @@ class ControllerCLISRv6(CustomCmd):
             args=['-help']
         )
 
-    def help_usid(self):
-        """Show help usage for usid command"""
+    def help_usid_policy(self):
+        """Show help usage for usid_policy command"""
 
         # pylint: disable=no-self-use
 
-        srv6_cli.parse_arguments_srv6_usid(
-            prog='usid',
-            args=['-help']
+        srv6_cli.parse_arguments_usid_policy(
+            prog='usid_policy',
+            args=['--help']
         )
 
 

--- a/control_plane/controller/controller/cli/srv6_cli.py
+++ b/control_plane/controller/controller/cli/srv6_cli.py
@@ -39,7 +39,7 @@ DEFAULT_CERTIFICATE = 'cert_server.pem'
 
 def handle_srv6_usid_policy(
         operation,
-        nodes_filename,
+        nodes_dict,
         lr_destination,
         rl_destination,
         nodes_lr=None,
@@ -61,7 +61,7 @@ def handle_srv6_usid_policy(
 
     res = srv6_usid.handle_srv6_usid_policy(
         operation=operation,
-        nodes_filename=nodes_filename,
+        nodes_dict=nodes_dict,
         lr_destination=lr_destination,
         rl_destination=rl_destination,
         nodes_lr=nodes_lr.split(',') if nodes_lr is not None else None,
@@ -871,7 +871,7 @@ def complete_srv6_biditunnel(text, prev_text=None):
     return args
 
 
-def args_srv6_usid():
+def args_load_nodes_config():
     '''
     Command-line arguments for the srv6_usid command
     Arguments are represented as a dicts. Each dict has two items:
@@ -894,15 +894,15 @@ def args_srv6_usid():
 
 
 # Parse options
-def parse_arguments_srv6_usid(prog=sys.argv[0], args=None):
-    """Command-line arguments parser for srv6_biditunnel function"""
+def parse_arguments_load_nodes_config(prog=sys.argv[0], args=None):
+    """Command-line arguments parser for load_nodes_config function"""
 
     # Get parser
     parser = ArgumentParser(
-        prog=prog, description='uSID'
+        prog=prog, description='Load nodes configuration to the database'
     )
     # Add the arguments to the parser
-    for param in args_srv6_usid():
+    for param in args_load_nodes_config():
         parser.add_argument(*param['args'], **param['kwargs'])
     # Parse input parameters
     args = parser.parse_args(args)
@@ -910,13 +910,76 @@ def parse_arguments_srv6_usid(prog=sys.argv[0], args=None):
     return args
 
 
-# TAB-completion for SRv6 bi-directional tunnel
-def complete_srv6_usid(text, prev_text=None):
+# TAB-completion for SRv6 uSID
+def complete_load_nodes_config(text, prev_text=None):
     """This function receives a string as argument and returns
     a list of parameters candidate for the auto-completion of the string"""
 
     # Get arguments for srv6_biditunnel
-    args = args_srv6_usid()
+    args = args_load_nodes_config()
+    # Paths auto-completion
+    if prev_text is not None:
+        # Get the list of the arguments requiring a path
+        path_args = [arg
+                     for param in args
+                     for arg in param['args']
+                     if param.get('is_path', False)]
+        # Check whether the previous argument requires a path or not
+        if prev_text in path_args:
+            # Auto-complete the path and return the results
+            return cli_utils.complete_path(text)
+    # Argument is not a path
+    #
+    # Get the list of the arguments supported by the command
+    args = [arg for param in args for arg in param['args']]
+    # Return the matching arguments
+    if text:
+        return [
+            arg for arg in args
+            if arg.startswith(text)
+        ]
+    # No argument provided: return all the available arguments
+    return args
+
+
+def args_print_nodes():
+    '''
+    Command-line arguments for the print_nodes command
+    Arguments are represented as a dicts. Each dict has two items:
+    - args, a list of names for the argument
+    - kwargs, a dict containing the attributes for the argument required by
+      the argparse library
+    - is_path, a boolean flag indicating whether the argument is a path or not
+    '''
+
+    return [
+    ]
+
+
+# Parse options
+def parse_arguments_print_nodes(prog=sys.argv[0], args=None):
+    """Command-line arguments parser for print_nodes function"""
+
+    # Get parser
+    parser = ArgumentParser(
+        prog=prog, description='Show the list of the available devices'
+    )
+    # Add the arguments to the parser
+    for param in args_print_nodes():
+        parser.add_argument(*param['args'], **param['kwargs'])
+    # Parse input parameters
+    args = parser.parse_args(args)
+    # Return the arguments
+    return args
+
+
+# TAB-completion for SRv6 uSID
+def complete_print_nodes(text, prev_text=None):
+    """This function receives a string as argument and returns
+    a list of parameters candidate for the auto-completion of the string"""
+
+    # Get arguments for srv6_biditunnel
+    args = args_print_nodes()
     # Paths auto-completion
     if prev_text is not None:
         # Get the list of the arguments requiring a path
@@ -945,3 +1008,8 @@ def complete_srv6_usid(text, prev_text=None):
 def print_node_to_addr_mapping(nodes_filename):
     '''Print mapping node to IP address'''
     srv6_usid.print_node_to_addr_mapping(nodes_filename)
+
+
+def print_nodes(nodes_dict):
+    '''Print nodes'''
+    srv6_usid.print_nodes(nodes_dict=nodes_dict)

--- a/control_plane/controller/controller/cli/srv6_cli.py
+++ b/control_plane/controller/controller/cli/srv6_cli.py
@@ -46,7 +46,15 @@ def handle_srv6_usid_policy(
         nodes_rl=None,
         table=-1,
         metric=-1,
-        _id=None):
+        _id=None,
+        l_grpc_ip=None,
+        l_grpc_port=None,
+        l_fwd_engine=None,
+        r_grpc_ip=None,
+        r_grpc_port=None,
+        r_fwd_engine=None,
+        decap_sid=None,
+        locator=None):
     """Handle a SRv6 uSID policy"""
 
     # pylint: disable=too-many-arguments
@@ -60,9 +68,18 @@ def handle_srv6_usid_policy(
         nodes_rl=nodes_rl.split(',') if nodes_rl is not None else None,
         table=table,
         metric=metric,
-        _id=_id
+        _id=_id,
+        l_grpc_ip=l_grpc_ip,
+        l_grpc_port=l_grpc_port,
+        l_fwd_engine=l_fwd_engine,
+        r_grpc_ip=r_grpc_ip,
+        r_grpc_port=r_grpc_port,
+        r_fwd_engine=r_fwd_engine,
+        decap_sid=decap_sid,
+        locator=locator
     )
-    print('%s\n\n' % utils.STATUS_CODE_TO_DESC[res])
+    if res is not None:
+        print('%s\n\n' % utils.STATUS_CODE_TO_DESC[res])
 
 
 def handle_srv6_path(
@@ -261,6 +278,48 @@ def args_srv6_usid_policy():
             'args': ['--id'],
             'kwargs': {'dest': 'id', 'action': 'store',
                        'help': 'id', 'type': int, 'default': None}
+        }, {
+            'args': ['--l-grpc-ip'],
+            'kwargs': {'dest': 'l_grpc_ip', 'action': 'store',
+                       'help': 'gRPC IP address of the left node',
+                       'type': str, 'default': None}
+        }, {
+            'args': ['--l-grpc-port'],
+            'kwargs': {'dest': 'l_grpc_port', 'action': 'store',
+                       'help': 'gRPC port of the left node',
+                       'type': int, 'default': None}
+        }, {
+            'args': ['--l-fwd-engine'],
+            'kwargs': {'dest': 'l_fwd_engine', 'action': 'store',
+                       'help': 'Forwarding engine for the left node '
+                       '(e.g. Linux or VPP)',
+                       'type': str, 'default': None}
+        }, {
+            'args': ['--r-grpc-ip'],
+            'kwargs': {'dest': 'r_grpc_ip', 'action': 'store',
+                       'help': 'gRPC IP address of the right node',
+                       'type': str, 'default': None}
+        }, {
+            'args': ['--r-grpc-port'],
+            'kwargs': {'dest': 'r_grpc_port', 'action': 'store',
+                       'help': 'gRPC port of the right node',
+                       'type': int, 'default': None}
+        }, {
+            'args': ['--r-fwd-engine'],
+            'kwargs': {'dest': 'r_fwd_engine', 'action': 'store',
+                       'help': 'Forwarding engine for the right node '
+                       '(e.g. Linux or VPP)',
+                       'type': str, 'default': None}
+        }, {
+            'args': ['--decap-sid'],
+            'kwargs': {'dest': 'decap_sid', 'action': 'store',
+                       'help': 'SID used for decap',
+                       'type': str, 'default': None}
+        }, {
+            'args': ['--locator'],
+            'kwargs': {'dest': 'locator', 'action': 'store',
+                       'help': 'Locator',
+                       'type': str, 'default': None}
         }, {
             'args': ['--debug'],
             'kwargs': {'action': 'store_true', 'help': 'Activate debug logs'}

--- a/control_plane/controller/controller/srv6_usid.py
+++ b/control_plane/controller/controller/srv6_usid.py
@@ -89,6 +89,16 @@ class InvalidSIDError(srv6_utils.SRv6Exception):
     '''
 
 
+def print_nodes(nodes_dict):
+    '''
+    Print the nodes.
+
+    :param nodes_dict: Dict containing the nodes
+    :type nodes_dict: dict
+    '''
+    print(list(nodes_dict.keys()))
+
+
 def print_node_to_addr_mapping(nodes_filename):
     '''
     This function reads a YAML file containing the mapping
@@ -678,7 +688,7 @@ def fill_nodes_info(nodes_info, nodes, l_grpc_ip=None, l_grpc_port=None,
             nodes_info[node_name] = node
 
 
-def handle_srv6_usid_policy(operation, nodes_filename=None,
+def handle_srv6_usid_policy(operation, nodes_dict=None,
                             lr_destination=None, rl_destination=None,
                             nodes_lr=None,
                             nodes_rl=None, table=-1, metric=-1,
@@ -692,9 +702,8 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
     :param operation: The operation to be performed on the uSID policy
                       (i.e. add, get, change, del)
     :type operation: str
-    :param nodes_filename: Name of the YAML file containing the
-                           mapping of node names to IP addresses
-    :type nodes_filename: str
+    :param nodes_dict: Dict containing the nodes configuration.
+    :type nodes_dict: dict
     :param destination: Destination of the SRv6 route
     :type destination: str
     :param nodes: Waypoints of the SRv6 route
@@ -767,7 +776,7 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
             return None
     if nodes_rl is None:
         pass
-    if nodes_filename is None:
+    if nodes_dict is None:
         if operation in ['add', 'del']:
             logger.error('"nodes_filename" argument is mandatory for %s '
                          'operation', operation)
@@ -810,7 +819,9 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
         # mapping of node names to IPv6 addresses is required
         #
         # Read nodes from YAML file
-        nodes_info, locator_bits, usid_id_bits = read_nodes(nodes_filename)
+        nodes_info = nodes_dict
+        locator_bits = DEFAULT_LOCATOR_BITS  # TODO configurable locator bits
+        usid_id_bits = DEFAULT_USID_ID_BITS  # TODO configurable uSID id bits
         # Add nodes list for the left-to-right path to the 'nodes_info' dict
         if nodes_lr is not None:
             fill_nodes_info(
@@ -872,7 +883,8 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
 
             policies = list(policies)
             for policy in policies:
-                # Add nodes list for the left-to-right path to the 'nodes_info' dict
+                # Add nodes list for the left-to-right path to the
+                # 'nodes_info' dict
                 if policy.get('lr_nodes') is not None:
                     fill_nodes_info(
                         nodes_info=nodes_info,
@@ -886,7 +898,8 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                         decap_sid=policy.get('decap_sid'),
                         locator=policy.get('locator')
                     )
-                # Add nodes list for the right-to-left path to the 'nodes_info' dict
+                # Add nodes list for the right-to-left path to the
+                # 'nodes_info' dict
                 if policy.get('rl_nodes') is not None:
                     fill_nodes_info(
                         nodes_info=nodes_info,

--- a/control_plane/controller/controller/srv6_usid.py
+++ b/control_plane/controller/controller/srv6_usid.py
@@ -450,7 +450,37 @@ def usid_id_to_usid(usid_id, locator):
                            (int(usid_id, 16) << 80)))
 
 
-def encode_endpoint_node(node, grpc_ip, grpc_port, fwd_engine, locator, udt=None):
+def encode_endpoint_node(node, grpc_ip, grpc_port, fwd_engine, locator,
+                         udt=None):
+    '''
+    Get a dict-representation of a node (endpoint of the path), starting from
+    gRPC IP and port, uDT sid, forwarding engine and locator.
+
+    :param node: Node identifier. This could be a name, a SID (IPv6 address)
+                 or a number (uSID identifier).
+    :type node: str
+    :param grpc_ip: gRPC IP address of the node.
+    :type grpc_ip: str
+    :param grpc_port: Port number of the gRPC server.
+    :type grpc_port: int
+    :param udt: uDT SID of the node, used for the decap operation. If not
+                provided, the uDT SID is not added to the SID list.
+    :type udt: str, optional
+    :param fwd_engine: Forwarding engine to be used (e.g. Linux or VPP).
+    :type fwd_engine: str
+    :param locator: Locator part of the SIDs (e.g. fcbb:bbbb::).
+    :type locator: str
+    :return: Dict representation of the node. The dict has the following
+             fields:
+             - name
+             - grpc_ip
+             - grpc_port
+             - uN
+             - uDT
+             - fwd_engine
+    :rtype: dict
+    :raises InvalidConfigurationError: If the node params are invalid.
+    '''
     # Validation checks
     #
     # Validate gRPC address
@@ -479,7 +509,11 @@ def encode_endpoint_node(node, grpc_ip, grpc_port, fwd_engine, locator, udt=None
         # Node identifier is a integer, we need to convert it to a SID (IPv6
         # address)
         un = usid_id_to_usid(node, locator)
+    # If the node is expressed as IPv6 address or uSID identifier, encode it
+    # Otherwise (if the node is expressed as node name), we return None and we
+    # expect to find the node info in the nodes configuration.
     if utils.validate_ipv6_address(node) or validate_usid_id(node):
+        # Return the dict
         return {
             'name': node,
             'grpc_ip': grpc_ip,
@@ -488,42 +522,116 @@ def encode_endpoint_node(node, grpc_ip, grpc_port, fwd_engine, locator, udt=None
             'uDT': udt,
             'fwd_engine': fwd_engine
         }
+    # 'Node' is a name. Return None.
     return None
 
 
 def encode_intermediate_node(node, locator):
+    '''
+    Get a dict-representation of a node (intermediate node of the path),
+    starting from gRPC IP and port, uDT sid, forwarding engine and locator.
+    For the intermediate nodes, we don't need uDT, forwarding engine.
+    gRPC IP and gRPC address.
+
+    :param node: Node identifier. This could be a name, a SID (IPv6 address)
+                 or a number (uSID identifier).
+    :type node: str
+    :param locator: Locator part of the SIDs (e.g. fcbb:bbbb::).
+    :type locator: str
+    :return: Dict representation of the node. The dict has the following
+             fields:
+             - name
+             - grpc_ip (set to None)
+             - grpc_port (set to None)
+             - uN
+             - uDT (set to None)
+             - fwd_engine (set to None)
+    :rtype: dict
+    :raises InvalidConfigurationError: If the node params are invalid.
+    '''
+    # Validate params
+    #
+    # Validate locator
     if locator is None:
         logger.error('locator is mandatory for node %s', node)
         raise InvalidConfigurationError
+    #
+    # Compute uN SID starting from the provided node identifier
+    # Node identifier can be expressed as SID (an IPv6 address) or a 
+    # uSID identifier. If it is a uSID identifier, we need to convert it
+    # to a SID.
     un = node
+    # Node identifier is a integer, we need to convert it to a SID (IPv6
+    # address)
     if validate_usid_id(node):
         un = usid_id_to_usid(node, locator)
+    # If the node is expressed as IPv6 address or uSID identifier, encode it
+    # Otherwise (if the node is expressed as node name), we return None and we
+    # expect to find the node info in the nodes configuration.
     if utils.validate_ipv6_address(node) or validate_usid_id(node):
         return {
             'name': node,
-            'grpc_ip': None,
-            'grpc_port': None,
+            'grpc_ip': None,    # Useless for intermediate nodes
+            'grpc_port': None,    # Useless for intermediate nodes
             'uN': un,
-            'uDT': None,
-            'fwd_engine': None
+            'uDT': None,    # Useless for intermediate nodes
+            'fwd_engine': None    # Useless for intermediate nodes
         }
+    # 'Node' is a name. Return None.
     return None
 
 
 def fill_nodes_info(nodes_info, nodes, l_grpc_ip=None, l_grpc_port=None,
                     l_fwd_engine=None, r_grpc_ip=None, r_grpc_port=None,
                     r_fwd_engine=None, decap_sid=None, locator=None):
-    # uDT
+    '''
+    Fill 'nodes_info' dict with the nodes containined in the 'nodes' list.
+
+    :param nodes_info: Dict containined the nodes information where to add the
+                       nodes.
+    :type nodes_info: dict
+    :param nodes: List of nodes. Each node can be expressed as SID (IPv6
+                  address), a uSID identifier (integer) or a name.
+    :type nodes: list
+    :param l_grpc_ip: gRPC address of the left node in the path.
+    :type l_grpc_ip: str, optional
+    :param l_grpc_port: Port number of the gRPC server on the left node of
+                        the path.
+    :type l_grpc_port: str, optional
+    :param l_fwd_engine: Forwarding engine to be used on the left node of
+                        the path (e.g. Linux or VPP).
+    :type l_fwd_engine: str, optional
+    :param r_grpc_ip: gRPC address of the right node in the path.
+    :type r_grpc_ip: str, optional
+    :param r_grpc_port: Port number of the gRPC server on the right node of
+                        the path.
+    :type r_grpc_port: str, optional
+    :param r_fwd_engine: Forwarding engine to be used on the right node of
+                        the path (e.g. Linux or VPP).
+    :type r_fwd_engine: str, optional
+    :param decap_sid: Decap SID. This could be a SID (IPv6 address) or a uSID
+                      identifier (an integer).
+    :type decap_sid: str, optional
+    :param locator: Locator part of the SIDs (e.g. fcbb:bbbb::).
+    :type locator: str, optional
+    :raises InvalidConfigurationError: If the node params are invalid.
+    '''
+    # Convert decap SID to uDT
     udt = None
     if decap_sid is not None:
+        # Locator is required
         if locator is None:
             logger.error('locator is mandatory')
-            return None
+            raise InvalidConfigurationError
+        # Check if decap SID is expressed as a SID (IPv6 address)
+        # or a uSID identifier (an integer)
         if not utils.validate_ipv6_address(decap_sid):
+            # Integer, we need to convert it to a SID (IPv6 address)
             udt = usid_id_to_usid(decap_sid, locator)
         else:
+            # IPv6 address
             udt = decap_sid
-    # Left node
+    # Encode left node
     #
     # A node could be expressed as an integer, an IPv6 address (SID)
     # or a name
@@ -535,9 +643,14 @@ def fill_nodes_info(nodes_info, nodes, l_grpc_ip=None, l_grpc_port=None,
         fwd_engine=l_fwd_engine,
         locator=locator
     )
+    # If we received a node info dict, we add it to the
+    # nodes info dictionary
     if node is not None:
         nodes_info[nodes[0]] = node
-    # Right node
+    # Encode right node
+    #
+    # A node could be expressed as an integer, an IPv6 address (SID)
+    # or a name
     node = encode_endpoint_node(
         node=nodes[-1],
         grpc_ip=r_grpc_ip,
@@ -546,14 +659,21 @@ def fill_nodes_info(nodes_info, nodes, l_grpc_ip=None, l_grpc_port=None,
         fwd_engine=r_fwd_engine,
         locator=locator
     )
+    # If we received a node info dict, we add it to the
+    # nodes info dictionary
     if node is not None:
         nodes_info[nodes[-1]] = node
-    # Intermediate nodes
+    # Encode intermediate nodes
+    # For the intermediate nodes, we don't need forwarding engine,
+    # uDT, gRPC IP and port
     for node_name in nodes[1:-1]:
+        # Encode the node
         node = encode_intermediate_node(
             node=node_name,
             locator=locator
         )
+        # If we received a node info dict, we add it to the
+        # nodes info dictionary
         if node is not None:
             nodes_info[node_name] = node
 
@@ -691,6 +811,7 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
         #
         # Read nodes from YAML file
         nodes_info, locator_bits, usid_id_bits = read_nodes(nodes_filename)
+        # Add nodes list for the left-to-right path to the 'nodes_info' dict
         if nodes_lr is not None:
             fill_nodes_info(
                 nodes_info=nodes_info,
@@ -704,6 +825,7 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                 decap_sid=decap_sid,
                 locator=locator
             )
+        # Add nodes list for the right-to-left path to the 'nodes_info' dict
         if nodes_rl is not None:
             fill_nodes_info(
                 nodes_info=nodes_info,
@@ -750,6 +872,7 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
 
             policies = list(policies)
             for policy in policies:
+                # Add nodes list for the left-to-right path to the 'nodes_info' dict
                 if policy.get('lr_nodes') is not None:
                     fill_nodes_info(
                         nodes_info=nodes_info,
@@ -763,6 +886,7 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                         decap_sid=policy.get('decap_sid'),
                         locator=policy.get('locator')
                     )
+                # Add nodes list for the right-to-left path to the 'nodes_info' dict
                 if policy.get('rl_nodes') is not None:
                     fill_nodes_info(
                         nodes_info=nodes_info,

--- a/control_plane/controller/controller/srv6_usid.py
+++ b/control_plane/controller/controller/srv6_usid.py
@@ -480,6 +480,29 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
     :param metric: Metric for the SRv6 route. If not provided, the default
                    metric will be used.
     :type metric: int, optional
+    :param l_grpc_ip: gRPC IP address of the left node, required if the left
+                      node is expressed numerically in the nodes list.
+    :type l_grpc_ip: str, optional
+    :param l_grpc_port: gRPC port of the left node, required if the left
+                        node is expressed numerically in the nodes list.
+    :type l_grpc_port: str, optional
+    :param l_fwd_engine: forwarding engine of the left node, required if the
+                         left node is expressed numerically in the nodes list.
+    :type l_fwd_engine: str, optional
+    :param r_grpc_ip: gRPC IP address of the right node, required if the right
+                      node is expressed numerically in the nodes list.
+    :type r_grpc_ip: str, optional
+    :param r_grpc_port: gRPC port of the right node, required if the right
+                        node is expressed numerically in the nodes list.
+    :type r_grpc_port: str, optional
+    :param r_fwd_engine: Forwarding engine of the right node, required if the
+                         right node is expressed numerically in the nodes
+                         list.
+    :type r_fwd_engine: str, optional
+    :param decap_sid: uSID used for the decap behavior (End.DT6).
+    :type decap_sid: str, optional
+    :param locator: Locator prefix (e.g. 'fcbb:bbbb::').
+    :type locator: str, optional
     :return: Status Code of the operation (e.g. 0 for STATUS_SUCCESS)
     :rtype: int
     :raises NodeNotFoundError: Node name not found in the mapping file
@@ -839,7 +862,6 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                     nodes = policy.get('lr_nodes')
                     for idx in range(len(nodes)):
                         node = str(nodes[idx])
-                        print('/*************************', node)
                         #if node in nodes_info:
                         #    # Config file contains node info, nothing to do
                         #    pass
@@ -992,13 +1014,11 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                             # logger.error('Unknown node: %s', node)
                             # return None
                             pass
-        print('\n\n', nodes_info)
         if len(policies) == 0:
             logger.error('Policy not found')
             return None
         # Iterate on the policies
         for policy in policies:
-            print(1)
             lr_destination = policy.get('lr_dst')
             rl_destination = policy.get('rl_dst')
             nodes_lr = policy.get('lr_nodes')
@@ -1015,11 +1035,9 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                 return None
             # Create the SRv6 Policy
             try:
-                print(2)
                 # # Prefix length for local segment
                 # prefix_len = locator_bits + usid_id_bits
                 # Ingress node
-                print(nodes_info)
                 ingress_node = nodes_info[nodes_lr[0]]
                 # Intermediate nodes
                 intermediate_nodes_lr = list()
@@ -1042,7 +1060,6 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                 with utils.get_grpc_session(ingress_node['grpc_ip'],
                                             ingress_node['grpc_port']
                                             ) as channel:
-                    print(3)
                     # Currently ony Linux and VPP are suppoted for the encap
                     if ingress_node['fwd_engine'] not in ['Linux', 'VPP']:
                         logger.error(
@@ -1098,16 +1115,6 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                         locator_bits=locator_bits,
                         usid_id_bits=usid_id_bits
                     )
-
-                    print(ingress_node)
-                    print(operation)
-                    print(lr_destination)
-                    print(usid_list)
-                    print(table)
-                    print(metric)
-                    print(bsid_addr)
-                    print(ingress_node['fwd_engine'])
-
                     # Handle a SRv6 path
                     response = srv6_utils.handle_srv6_path(
                         operation=operation,
@@ -1177,7 +1184,6 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                 with utils.get_grpc_session(egress_node['grpc_ip'],
                                             egress_node['grpc_port']
                                             ) as channel:
-                    print(4)
                     # Currently ony Linux and VPP are suppoted for the encap
                     if egress_node['fwd_engine'] not in ['Linux', 'VPP']:
                         logger.error(
@@ -1271,16 +1277,6 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                         locator_bits=locator_bits,
                         usid_id_bits=usid_id_bits
                     )
-
-                    print()
-                    print(egress_node)
-                    print(operation)
-                    print(rl_destination)
-                    print(usid_list)
-                    print(table)
-                    print(metric)
-                    print(bsid_addr)
-                    print(egress_node['fwd_engine'])
                     # Handle a SRv6 path
                     response = srv6_utils.handle_srv6_path(
                         operation=operation,
@@ -1298,7 +1294,6 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                         return response
                 # Persist uSID policy to database
                 if persistency:
-                    print(5)
                     if operation == 'add':
                         # Connect to ArangoDB
                         client = arangodb_driver.connect_arango(
@@ -1350,9 +1345,7 @@ def handle_srv6_usid_policy(operation, nodes_filename=None,
                             metric=metric if metric != -1 else None
                         )
                     else:
-                        print('errrrr')
                         logger.error('Unsupported operation: %s', operation)
-                    print(6)
             except (InvalidConfigurationError, NodeNotFoundError,
                     TooManySegmentsError, SIDLocatorError, InvalidSIDError):
                 return commons_pb2.STATUS_INTERNAL_ERROR

--- a/docs/controller/cli/srv6.rst
+++ b/docs/controller/cli/srv6.rst
@@ -20,7 +20,7 @@ The ``srv6`` section supports the following commands:
 
 .. code:: bash
 
-  behavior  biditunnel  exit  help  path  unitunnel usid
+  behavior  biditunnel  exit  help  path  unitunnel usid_policy
 
 
 ``behavior``
@@ -602,19 +602,133 @@ Create, get, change or remove a unidirectional SRv6 tunnel between two nodes.
         | enabled.
 
 
-``usid``
---------
+``usid_policy``
+----------
 
-Enter the ``usid`` sub-section of the ``srv6`` CLI.
-This command requires the argument --addrs-file, that is a YAML file
-containing the mapping of node names to IP addresses.
+Create, get, change or remove a SRv6 uSID policy in a node.
 
 .. code:: bash
 
-  controller(srv6)> usid --nodes-file nodes.yml
+  controller(srv6)> policy --help
+  usage: policy [-h] [--secure] [--server-cert SERVER_CERT] --op OP
+                [--lr-destination LR_DESTINATION]
+                [--rl-destination RL_DESTINATION] [--nodes NODES]
+                [--nodes-rev NODES_REV] [--table TABLE] [--metric METRIC]
+                [--id ID] [--debug]
 
-See :ref:`controller-cli-srv6-usid` for a description
-of the commands available in the ``usid`` section.
+  gRPC Southbound APIs for SRv6 Controller
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    --secure              Activate secure mode
+    --server-cert SERVER_CERT
+                          CA certificate file
+    --op OP               Operation
+    --lr-destination LR_DESTINATION
+                          Left to Right Destination
+    --rl-destination RL_DESTINATION
+                          Right to Left Destination
+    --nodes NODES         Nodes
+    --nodes-rev NODES_REV
+                          Reverse nodes list
+    --table TABLE         Table
+    --metric METRIC       Metric
+    --id ID               id
+    --debug               Activate debug logs
+
+
+.. list-table:: Arguments for the ``policy`` command
+    :widths: 15 15 10 10 60
+    :header-rows: 1
+
+
+    * - Argument
+      - Type
+      - Default
+      - Optional
+      - Description
+    * - ``--help``
+      - --
+      - --
+      - --
+      - Show an help message and exit.
+    * - ``--secure``
+      - boolean
+      - False
+      - yes
+      - | If True, the Controller will use the TLS to
+        | encrypt and authenticate the traffic sent
+        | to the Node Manager on the gRPC
+        | Channel.
+    * - ``--server-cert``
+      - string
+      - None
+      - yes
+      - | Name of CA certificate for the TLS,
+        | required if GRPC_SECURE is True.
+    * - ``--op``
+      - string
+      - --
+      - no
+      - Operation (add, change, get, del).
+    * - ``--lr-destination``
+      - string
+      - --
+      - yes
+      - Destination of the SRv6 left-to-right path.
+    * - ``--rl-destination``
+      - string
+      - --
+      - yes
+      - Destination of the SRv6 right-to-left path.
+    * - ``--nodes``
+      - string
+      - --
+      - yes
+      - | The list of the waypoints (device names) of
+        | the SRv6 path (left-to-right).
+    * - ``--nodes-rev``
+      - string
+      - --
+      - yes
+      - | The list of the waypoints (device names) of the
+        | reverse SRv6 path (right-to-left).
+        | If not provided, the same nodes of the
+        | left-to-right path in reverse order
+        | will be used.
+    * - ``--device``
+      - string
+      - --
+      - yes
+      - | Device to be associated to the SRv6
+        | path. If not specified, the Node
+        | Manager will select an interface
+        | automatically from the list of the
+        | interfaces of the device.
+    * - ``--encapmode``
+      - string
+      - encap
+      - yes
+      - | The encap mode used for SRv6
+        | (i.e. encap, inline or l2encap).
+    * - ``--table``
+      - integer
+      - 254
+      - yes
+      - | The ID of the table where the SRv6
+        | route must be created or removed
+        | from. If not specified, the main table will
+        | be used (table ID 254).
+    * - ``--metric``
+      - integer
+      - --
+      - yes
+      - The metric to be assigned to the route.
+    * - ``--debug``
+      - --
+      - --
+      - yes
+      - If True, the debug logging is enabled.
 
 
 ``exit``
@@ -635,10 +749,3 @@ Show a description of the commands.
 .. code:: bash
 
   controller(srv6)> help
-
-
-.. toctree ::
-   :maxdepth: 2
-   :hidden:
-
-   srv6_usid

--- a/docs/controller/cli/topology.rst
+++ b/docs/controller/cli/topology.rst
@@ -21,7 +21,9 @@ Section ``topology`` supports the following commands:
 
 .. code:: console
 
-  exit  extract  extract_and_load_on_arango  help  load_on_arango
+  extract                     help               load_on_arango  exit
+  extract_and_load_on_arango  load_nodes_config  print_nodes   
+
 
 
 ``extract``
@@ -140,6 +142,36 @@ Read the topology from a YAML file and load it on a ArangoDB database.
                           edges_yaml
     -v, --verbose         Enable verbose mode
     -d, --debug           Activate debug logs
+
+
+``load_nodes_config``
+---------------------
+
+Load nodes configuration to the database.
+
+.. code:: bash
+
+  controller(topology)> load_nodes_config --help
+  usage: load_nodes_config [-h] --nodes-file NODES_FILE
+
+  Load nodes configuration to the database
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    --nodes-file NODES_FILE
+                          File containing the mapping of name nodes to IP
+                          addresses
+
+
+``show_nodes``
+--------------
+
+Print the list of the available nodes.
+
+.. code:: bash
+
+  controller(topology)> show_nodes
+  Show the list of the available devices
 
 
 ``exit``


### PR DESCRIPTION
This PR will add the support for SID lists expressed numerically in uSID policies. For example,

With this PR, to create a uSID policy you can mix uSID identifiers, uN SIDs and node names. For example:
`usid_policy --op add --lr-destination fd00:0:32::2 --rl-destination fd00:0:11::2 --nodes r1,0002,fcbb:bbbb:0003:: --r-grpc-ip fcfd:0:0:3::1 --r-grpc-port 12345 --r-fwd-engine Linux --decap-sid f00d --locator fcbb:bbbb::`

Also, this PR will enable the persistency of the nodes configuration on the database.